### PR TITLE
Ignore picture documents for streaks

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -114,6 +114,7 @@ function ReadingStreak:onReaderReady()
 end
 
 function ReadingStreak:onPageUpdate(pageno)
+    if self.document and self.document.is_pic then return end
     if self.settings.auto_track ~= false then
         self:updateDailyProgress(pageno)
         self:checkStreak()


### PR DESCRIPTION
Those documents are ignored by Reading Statistics too. So it probably makes sense to ignore them for Reading Streaks too.